### PR TITLE
Bunch 6.x.x. Patches

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -20,6 +20,7 @@ package io.invertase.firebase.auth;
 import android.app.Activity;
 import android.net.Uri;
 import android.os.Parcel;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
@@ -941,6 +942,18 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     final String verificationCode,
     final Promise promise
   ) {
+    if (TextUtils.isEmpty(mVerificationId) || TextUtils.isEmpty(verificationCode)) {
+      Exception exception = new IllegalArgumentException(
+        "Cannot create PhoneAuthCredential. Both verificationId and verificationCode cannot be empty.");
+      Log.e(
+        TAG,
+        "confirmationResultConfirm:precondition",
+        exception
+      );
+      promiseRejectAuthException(promise, exception);
+      return;
+    }
+
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
     FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
 
@@ -1384,8 +1397,10 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
       return credential;
     }
 
-    if (authToken != null) {
+    if (!TextUtils.isEmpty(authToken) && !TextUtils.isEmpty(authSecret)) {
       return PhoneAuthProvider.getCredential(authToken, authSecret);
+    } else {
+      Log.w(TAG, "getPhoneAuthCredential: Failed to create PhoneAuthProvider credentials. Both authToken and authSecret cannot be empty.");
     }
 
     return null;

--- a/packages/auth/lib/PhoneAuthListener.js
+++ b/packages/auth/lib/PhoneAuthListener.js
@@ -28,7 +28,7 @@ export default class PhoneAuthListener {
     this._promise = null;
     this._jsStack = new Error().stack;
 
-    this._timeout = timeout || 20;
+    this._timeout = typeof timeout === 'number' && 0 <= timeout ? timeout : 20;
     this._phoneAuthRequestId = REQUEST_ID++;
     this._forceResending = forceResend || false;
 

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseCommon.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseCommon.m
@@ -76,7 +76,9 @@ NSString *const DATABASE_PERSISTENCE_CACHE_SIZE = @"firebase_database_persistenc
     firDatabase.callbackQueue = [RNFBDatabaseCommon getDispatchQueue];
     // Persistence enabled
     BOOL *persistenceEnabled = (BOOL *) [preferences getBooleanValue:DATABASE_PERSISTENCE_ENABLED defaultValue:false];
-    [firDatabase setPersistenceEnabled:(BOOL) persistenceEnabled];
+    if (firDatabase.persistenceEnabled != (BOOL)persistenceEnabled){
+        [firDatabase setPersistenceEnabled:(BOOL) persistenceEnabled];
+    }
 
     // Logging enabled
     BOOL *loggingEnabled = (BOOL *) [preferences getBooleanValue:DATABASE_LOGGING_ENABLED defaultValue:false];

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseReferenceModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseReferenceModule.m
@@ -44,7 +44,13 @@ RCT_EXPORT_METHOD(set:
     : (RCTPromiseRejectBlock)reject
 ) {
   FIRDatabase *firDatabase = [RNFBDatabaseCommon getDatabaseForApp:firebaseApp dbURL:dbURL];
-  FIRDatabaseReference *firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  FIRDatabaseReference *firDatabaseReference;
+  @try {
+    firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  } @catch (NSException *exception) {
+    resolve([NSNull null]);
+    return;
+  }
 
   [firDatabaseReference setValue:[props valueForKey:@"value"] withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
     if (error != nil) {
@@ -64,7 +70,13 @@ RCT_EXPORT_METHOD(update:
     : (RCTPromiseRejectBlock)reject
 ) {
   FIRDatabase *firDatabase = [RNFBDatabaseCommon getDatabaseForApp:firebaseApp dbURL:dbURL];
-  FIRDatabaseReference *firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  FIRDatabaseReference *firDatabaseReference;
+  @try {
+    firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  } @catch (NSException *exception) {
+    resolve([NSNull null]);
+    return;
+  }
 
   [firDatabaseReference updateChildValues:[props valueForKey:@"values"] withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
     if (error != nil) {
@@ -84,7 +96,13 @@ RCT_EXPORT_METHOD(setWithPriority:
     : (RCTPromiseRejectBlock)reject
 ) {
   FIRDatabase *firDatabase = [RNFBDatabaseCommon getDatabaseForApp:firebaseApp dbURL:dbURL];
-  FIRDatabaseReference *firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  FIRDatabaseReference *firDatabaseReference;
+  @try {
+    firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  } @catch (NSException *exception) {
+    resolve([NSNull null]);
+    return;
+  }
 
   [firDatabaseReference setValue:[props valueForKey:@"value"] andPriority:[props valueForKey:@"priority"] withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
     if (error != nil) {
@@ -103,8 +121,13 @@ RCT_EXPORT_METHOD(remove:
     : (RCTPromiseRejectBlock)reject
 ) {
   FIRDatabase *firDatabase = [RNFBDatabaseCommon getDatabaseForApp:firebaseApp dbURL:dbURL];
-  FIRDatabaseReference *firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
-
+  FIRDatabaseReference *firDatabaseReference;
+  @try {
+    firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  } @catch (NSException *exception) {
+    resolve([NSNull null]);
+    return;
+  }
   [firDatabaseReference removeValueWithCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
     if (error != nil) {
       [RNFBDatabaseCommon promiseRejectDatabaseException:reject error:error];
@@ -123,7 +146,13 @@ RCT_EXPORT_METHOD(setPriority:
     : (RCTPromiseRejectBlock)reject
 ) {
   FIRDatabase *firDatabase = [RNFBDatabaseCommon getDatabaseForApp:firebaseApp dbURL:dbURL];
-  FIRDatabaseReference *firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  FIRDatabaseReference *firDatabaseReference;
+  @try {
+    firDatabaseReference = [RNFBDatabaseCommon getReferenceForDatabase:firDatabase path:path];
+  } @catch (NSException *exception) {
+    resolve([NSNull null]);
+    return;
+  }
 
   [firDatabaseReference setPriority:[props valueForKey:@"priority"] withCompletionBlock:^(NSError *error, FIRDatabaseReference *ref) {
     if (error != nil) {


### PR DESCRIPTION
Re-applying 6.x.x patches:

- [Auth] Allowing auto-verify to be disabled.
- [Auth] Fixed crash caused by unsafe PhoneAuthCredential creation.
- [Database] Adds a check to see if the persistence needs to be re-set. This will avoid some potential crashes.
- [Database] Adds try catch around database reference retrieval.

Skipped patches:
- [Messaging] Crash fix caused by ReactNativeFirebaseMessagingModule.getInitialNotification - Already fixed in the upstream

